### PR TITLE
GPGME example update

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ server = KeyServer("hkps://pgp.ext.selfnet.de",
 ## Import key with gpgme python bindings
 
 ```python
+from __future__ import absolute_import, unicode_literals
+
 import gpg
 
-with gpg.Context(armor=True, home_dir=HOME) as gnupg:
-    result = gnupg.op_import(key.key.encode('ascii'))
-
+result = gpg.Context().key_import(key.key.encode("utf-8"))
 ```

--- a/hkp4py/client.py
+++ b/hkp4py/client.py
@@ -1,5 +1,5 @@
 """
-Python HKP procol client implementation based on current draft spec
+Python HKP protocol client implementation based on current draft spec
 http://tools.ietf.org/html/draft-shaw-openpgp-hkp-00
 
 Taken from: 
@@ -19,6 +19,7 @@ __all__ = ['Key', 'Identity', 'KeyServer']
 
 # Loosely taken from RFC2440 (http://tools.ietf.org/html/rfc2440#section-9.1)
 ALGORITHMS = {
+    0: 'unknown',
     1: 'RSA (Encrypt or Sign)',
     2: 'RSA Encrypt-Only',
     3: 'RSA Sign-Only',
@@ -27,6 +28,8 @@ ALGORITHMS = {
     18: 'Elliptic Curve',
     19: 'ECDSA',
     20: 'Elgamal (Encrypt or Sign)',
+    21: 'Reserved for Diffie-Hellman',
+    22: 'EdDSA',
 }
 
 


### PR DESCRIPTION
    * Updated context: armor unnecessary with import and home_dir default
      is None anyway.
    * Encoding should be UTF-8 and bytes literals for imports, UTF-8 is
      the default in Python 3, but to maintain py2 support we need to be
      explicit.
    * Finally, people should not use the op_* layer when the more pythonic
      layer above it does what they need.