### PR TITLE
Better error handling

### DIFF
--- a/hkp4py/client.py
+++ b/hkp4py/client.py
@@ -215,8 +215,11 @@ class KeyServer(object):
             params=params)
         if response.ok:
             response = response.text
-        else:
+        elif response.status_code == requests.codes.not_found:
             return None
+        else:
+            raise Exception(
+                '{}\nRequest URL: {}\nResponse:\n{}'.format(response.status_code, response.request.url, response.text))
         return self.__parse_index(response)
 
     def add(self, key):


### PR DESCRIPTION
It could be important to differentiate between a failed connection attempt
to a key server and the situation that a key was not found, but search()
returned None in both cases.

Therefore, this commit changes the behaviour from silently ignoring HTTP
connection errors to explicitly handling the case that a key was not found
(status code 404) in which case None is returned instead of a key or an error
occurred in which case an Exception is raised with detailed error information.