### PR TITLE
Change parameter order in query string

### DIFF
--- a/hkp4py/client.py
+++ b/hkp4py/client.py
@@ -203,9 +203,9 @@ class KeyServer(object):
         )
 
         params = {
-            'search': query,
             'op': 'index',
             'options': ','.join(name for name, val in opts if val),
+            'search': query,
             'exact': exact and 'on' or 'off',
         }
 


### PR DESCRIPTION
Hagrid servers fail responding when the op parameter is not the first one.

Although this should be fixed in Hagrid (see
https://gitlab.com/hagrid-keyserver/hagrid/issues/142 for bug report) this can
be mitigated without causing any trouble with other keyservers by rearranging
the parameter order in hkp4py's requests.