### PR TITLE
Feature/gpg vks

### DIFF
--- a/hkp4py/protocols/vks.py
+++ b/hkp4py/protocols/vks.py
@@ -2,7 +2,7 @@ from typing import Union
 
 from requests import Session, codes
 
-import hkp4py.exceptions as exceptions
+from .. import exceptions
 
 from .key import IKey
 


### PR DESCRIPTION
This fixes the following problem when trying to import the hkp4py module from the branch feature/gpg-vks:

```
>>> import hkp4py
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jan/Projekte/hkp4py/hkp4py/__init__.py", line 4, in <module>
    from .client import HKPClient, HKPClient as KeyServer
  File "/home/jan/Projekte/hkp4py/hkp4py/client.py", line 5, in <module>
    from .exceptions import MalformedURL, UnsupportedProtocol
  File "/home/jan/Projekte/hkp4py/hkp4py/exceptions.py", line 1, in <module>
    from .protocols import Protocol
  File "/home/jan/Projekte/hkp4py/hkp4py/protocols/__init__.py", line 4, in <module>
    from .vks import VKSKey
  File "/home/jan/Projekte/hkp4py/hkp4py/protocols/vks.py", line 5, in <module>
    import hkp4py.exceptions as exceptions
AttributeError: module 'hkp4py' has no attribute 'exceptions'
```
