### PR TITLE
Distinguish client errors

### DIFF
--- a/hkp4py/__init__.py
+++ b/hkp4py/__init__.py
@@ -2,5 +2,5 @@
 Python HKP client module
 """
 
-from hkp4py.client import Key, Identity, KeyServer
-__all__ = ['Key', 'Identity', 'KeyServer']
+from vendor.hkp4py.client import Key, Identity, KeyServer, HTTPClientError
+__all__ = ['Key', 'Identity', 'KeyServer', 'HTTPClientError']


### PR DESCRIPTION
Currently it's not possible to distinguish between

a) Server Errors (HTTP Codes 5xx)
b) Redirects (HTTP Codes 3xx)
c) Client Errors (HTTP Codes 4xx)

when retrieving a key. I propose the attached change so that at least client and server errors can be distinguished, because an application may need to handle the case of an invalid key differently than the case of a (temporarily) unavailable keyserver.
 